### PR TITLE
net/x/search: support ZIP64 archives (real X exports are ZIP64)

### DIFF
--- a/net/x/search/README.md
+++ b/net/x/search/README.md
@@ -45,8 +45,10 @@ robust path.
   and inflated with the browser-native `DecompressionStream('deflate-raw')`. The
   archive is read by *slicing* the file (only the few MB we need — the tweet
   files, not the media), so a large archive is never loaded whole into memory.
-  Archives over 4GB (ZIP64) aren't supported — extract `data/tweets.js` and drop
-  that instead.
+- **ZIP64.** X streams its archives, which forces ZIP64 (64-bit offsets stored
+  in extra fields, with a ZIP64 end-of-directory record). The reader resolves
+  those, so real multi-GB archives import directly; anything it still can't read
+  gives a clear "extract data/tweets.js" message rather than crashing.
 - **Index.** Tweets are tokenized into an in-memory inverted index (token →
   tweet ids) for fast AND queries; phrases fall back to substring matching.
 - **Storage.** Normalized tweets live in IndexedDB, so reloads are instant.

--- a/net/x/search/lib.js
+++ b/net/x/search/lib.js
@@ -82,17 +82,21 @@ export async function readZip(blob, want) {
 
     // ZIP64 extended-info extra field (id 0x0001): the values that were stored
     // as the 0xFFFFFFFF sentinel appear here as 8-byte ints, in the fixed order
-    // uncompressed, compressed, localHeaderOffset.
+    // uncompressed, compressed, localHeaderOffset. Every read is bounds-checked
+    // against the sub-record so a truncated/malformed field yields the clear
+    // error below instead of an out-of-bounds DataView throw.
     if (compSize === SENT || localOff === SENT || uncSize === SENT) {
       let ep = p + 46 + nameLen;
-      const extraEnd = ep + extraLen;
+      const extraEnd = Math.min(ep + extraLen, cd.byteLength);
       while (ep + 4 <= extraEnd) {
         const id = cd.getUint16(ep, true), len = cd.getUint16(ep + 2, true);
+        const bodyEnd = Math.min(ep + 4 + len, extraEnd);
         if (id === 0x0001) {
           let dp = ep + 4;
-          if (uncSize  === SENT) dp += 8;                                       // skip; unused
-          if (compSize === SENT) { compSize = Number(cd.getBigUint64(dp, true)); dp += 8; }
-          if (localOff === SENT) { localOff = Number(cd.getBigUint64(dp, true)); dp += 8; }
+          const next = () => { if (dp + 8 > bodyEnd) throw badZip(); const v = Number(cd.getBigUint64(dp, true)); dp += 8; return v; };
+          if (uncSize  === SENT) next();                       // present but unused
+          if (compSize === SENT) compSize = next();
+          if (localOff === SENT) localOff = next();
           break;
         }
         ep += 4 + len;
@@ -105,18 +109,25 @@ export async function readZip(blob, want) {
 
   const out = new Map();
   for (const e of wanted) {
-    if (e.localOff < 0 || e.localOff + 30 > size || e.localOff + 30 + e.compSize > size) {
-      throw new Error('Could not read this ZIP (bad entry offset). '
-        + 'Extract data/tweets.js from the ZIP and drop just that file instead.');
-    }
+    // A sentinel that survived means an unresolved ZIP64 offset; the local-file
+    // signature check catches any offset that still lands on the wrong bytes.
+    if (e.localOff === SENT || e.compSize === SENT
+        || e.localOff < 0 || e.localOff + 30 > size) throw badZip();
+    const lh = await view(e.localOff, e.localOff + 30);
+    if (lh.byteLength < 30 || lh.getUint32(0, true) !== 0x04034b50) throw badZip();
     // The local header's own name/extra lengths tell us where data starts
     // (they can differ from the central directory's).
-    const lh = await view(e.localOff, e.localOff + 30);
     const dataStart = e.localOff + 30 + lh.getUint16(26, true) + lh.getUint16(28, true);
+    if (dataStart + e.compSize > size) throw badZip();
     const raw = new Uint8Array(await blob.slice(dataStart, dataStart + e.compSize).arrayBuffer());
     out.set(e.name, e.method === 0 ? raw : await inflateRaw(raw));
   }
   return out;
+}
+
+function badZip() {
+  return new Error('Could not read this ZIP (bad entry offset). '
+    + 'Extract data/tweets.js from the ZIP and drop just that file instead.');
 }
 
 

--- a/net/x/search/lib.js
+++ b/net/x/search/lib.js
@@ -11,32 +11,51 @@ export async function inflateRaw(bytes) {
   return new Uint8Array(await new Response(stream).arrayBuffer());
 }
 
-// Minimal reader for standard (non-zip64) ZIP archives. Only entries whose
-// name passes `want` are decompressed. Returns Map(filename -> Uint8Array).
+// Reader for ZIP archives, including ZIP64. Only entries whose name passes
+// `want` are decompressed. Returns Map(filename -> Uint8Array).
 //
 // Reads by slicing the Blob (EOCD tail -> central directory -> just the wanted
 // local entries), so a multi-GB archive-with-media is never loaded into memory:
 // we only touch the few MB we actually need.
+//
+// ZIP64 matters here because X generates archives by *streaming*, and streaming
+// zip writers force ZIP64: entry sizes/offsets are stored as 0xFFFFFFFF
+// sentinels with the real 64-bit values in a ZIP64 extra field, and the central
+// directory is located via a ZIP64 end-of-directory record. We resolve both.
 export async function readZip(blob, want) {
   const size = blob.size;
   const dec = new TextDecoder();
-  const slice = async (start, end) => new DataView(await blob.slice(start, end).arrayBuffer());
+  const SENT = 0xffffffff;
+  const view = async (start, end) =>
+    new DataView(await blob.slice(Math.max(0, start), Math.min(end, size)).arrayBuffer());
 
   // Locate End Of Central Directory record: it lies within the last
   // 22 + 65535 bytes (fixed record + max comment).
   const tailLen = Math.min(size, 22 + 0xffff);
-  const tail = await slice(size - tailLen, size);
+  const tail = await view(size - tailLen, size);
   let eo = -1;
   for (let i = tail.byteLength - 22; i >= 0; i--) {
     if (tail.getUint32(i, true) === 0x06054b50) { eo = i; break; }
   }
   if (eo < 0) throw new Error('Not a ZIP file (no end-of-central-directory record).');
 
-  const count  = tail.getUint16(eo + 10, true);
-  const cdSize = tail.getUint32(eo + 12, true);
-  const cdOff  = tail.getUint32(eo + 16, true);
-  if (cdOff === 0xffffffff || count === 0xffff) {
-    throw new Error('This archive is 4GB+ (ZIP64), which this reader does not support. '
+  let count  = tail.getUint16(eo + 10, true);
+  let cdSize = tail.getUint32(eo + 12, true);
+  let cdOff  = tail.getUint32(eo + 16, true);
+
+  // ZIP64: a locator (0x07064b50) sits immediately before the classic EOCD and
+  // points at the ZIP64 EOCD record (0x06064b50), which holds 64-bit count/offset.
+  if (eo >= 20 && tail.getUint32(eo - 20, true) === 0x07064b50) {
+    const z64Off = Number(tail.getBigUint64(eo - 20 + 8, true));
+    const z = await view(z64Off, z64Off + 56);
+    if (z.byteLength >= 56 && z.getUint32(0, true) === 0x06064b50) {
+      count  = Number(z.getBigUint64(32, true));
+      cdSize = Number(z.getBigUint64(40, true));
+      cdOff  = Number(z.getBigUint64(48, true));
+    }
+  }
+  if (cdOff === SENT || cdSize === SENT || cdOff + cdSize > size) {
+    throw new Error('Could not read this ZIP (unresolved ZIP64 directory). '
       + 'Extract data/tweets.js from the ZIP and drop just that file instead.');
   }
 
@@ -53,21 +72,46 @@ export async function readZip(blob, want) {
   for (let i = 0; i < count && p + 46 <= cd.byteLength; i++) {
     if (cd.getUint32(p, true) !== 0x02014b50) break;
     const method   = cd.getUint16(p + 10, true);
-    const compSize = cd.getUint32(p + 20, true);
+    const uncSize  = cd.getUint32(p + 24, true);
+    let   compSize = cd.getUint32(p + 20, true);
     const nameLen  = cd.getUint16(p + 28, true);
     const extraLen = cd.getUint16(p + 30, true);
     const cmtLen   = cd.getUint16(p + 32, true);
-    const localOff = cd.getUint32(p + 42, true);
+    let   localOff = cd.getUint32(p + 42, true);
     const name     = dec.decode(cdu8.subarray(p + 46, p + 46 + nameLen));
+
+    // ZIP64 extended-info extra field (id 0x0001): the values that were stored
+    // as the 0xFFFFFFFF sentinel appear here as 8-byte ints, in the fixed order
+    // uncompressed, compressed, localHeaderOffset.
+    if (compSize === SENT || localOff === SENT || uncSize === SENT) {
+      let ep = p + 46 + nameLen;
+      const extraEnd = ep + extraLen;
+      while (ep + 4 <= extraEnd) {
+        const id = cd.getUint16(ep, true), len = cd.getUint16(ep + 2, true);
+        if (id === 0x0001) {
+          let dp = ep + 4;
+          if (uncSize  === SENT) dp += 8;                                       // skip; unused
+          if (compSize === SENT) { compSize = Number(cd.getBigUint64(dp, true)); dp += 8; }
+          if (localOff === SENT) { localOff = Number(cd.getBigUint64(dp, true)); dp += 8; }
+          break;
+        }
+        ep += 4 + len;
+      }
+    }
+
     p += 46 + nameLen + extraLen + cmtLen;
     if (want(name)) wanted.push({ name, method, compSize, localOff });
   }
 
   const out = new Map();
   for (const e of wanted) {
+    if (e.localOff < 0 || e.localOff + 30 > size || e.localOff + 30 + e.compSize > size) {
+      throw new Error('Could not read this ZIP (bad entry offset). '
+        + 'Extract data/tweets.js from the ZIP and drop just that file instead.');
+    }
     // The local header's own name/extra lengths tell us where data starts
     // (they can differ from the central directory's).
-    const lh = await slice(e.localOff, e.localOff + 30);
+    const lh = await view(e.localOff, e.localOff + 30);
     const dataStart = e.localOff + 30 + lh.getUint16(26, true) + lh.getUint16(28, true);
     const raw = new Uint8Array(await blob.slice(dataStart, dataStart + e.compSize).arrayBuffer());
     out.set(e.name, e.method === 0 ? raw : await inflateRaw(raw));

--- a/net/x/search/lib.test.mjs
+++ b/net/x/search/lib.test.mjs
@@ -142,7 +142,9 @@ eq(parseHandle(dec.decode(entries.get('data/account.js'))), 'pmayrgundter', 'zip
 // --- Real ZIP64 archive (streaming-writer style): per-entry 0xffffffff offset
 // sentinels + ZIP64 extra fields + ZIP64 end-of-directory record/locator.
 // This is the shape X's streamed archives use and what crashed the old reader.
-function makeZip64(entries) {
+// noExtra: mark localOff as a sentinel but write NO resolving extra field, to
+// exercise the "unresolved ZIP64" guard (must error cleanly, not crash).
+function makeZip64(entries, { noExtra = false } = {}) {
   const locals = [], centrals = []; let off = 0;
   for (const e of entries) {
     const nb = Buffer.from(e.name), comp = e.deflate ? zlib.deflateRawSync(e.data) : e.data, method = e.deflate ? 8 : 0;
@@ -153,12 +155,20 @@ function makeZip64(entries) {
 
     const ch = Buffer.alloc(46);
     ch.writeUInt32LE(0x02014b50, 0); ch.writeUInt16LE(method, 10);
-    ch.writeUInt32LE(comp.length, 20); ch.writeUInt32LE(e.data.length, 24);
     ch.writeUInt16LE(nb.length, 28);
-    const extra = Buffer.alloc(12);                 // zip64 extra: real local offset
-    extra.writeUInt16LE(0x0001, 0); extra.writeUInt16LE(8, 2); extra.writeBigUInt64LE(BigInt(off), 4);
+    // Sentinel ALL THREE fields (uncompressed, compressed, local offset) — the
+    // shape streaming zip writers actually emit — and carry the real 64-bit
+    // values in the extra field, in canonical order.
+    ch.writeUInt32LE(0xffffffff, 20); ch.writeUInt32LE(0xffffffff, 24); ch.writeUInt32LE(0xffffffff, 42);
+    let extra = Buffer.alloc(0);
+    if (!noExtra) {
+      extra = Buffer.alloc(28);
+      extra.writeUInt16LE(0x0001, 0); extra.writeUInt16LE(24, 2);
+      extra.writeBigUInt64LE(BigInt(e.data.length), 4);   // uncompressed
+      extra.writeBigUInt64LE(BigInt(comp.length), 12);    // compressed
+      extra.writeBigUInt64LE(BigInt(off), 20);            // local header offset
+    }
     ch.writeUInt16LE(extra.length, 30);
-    ch.writeUInt32LE(0xffffffff, 42);               // local offset = sentinel
     centrals.push(Buffer.concat([ch, nb, extra]));
     locals.push(lr); off += lr.length;
   }
@@ -186,8 +196,15 @@ const zip64 = makeZip64([
   { name: 'data/account.js', data: Buffer.from(accountJs), deflate: false },
 ]);
 const e64 = await readZip(new Blob([zip64]), want);
-eq(parseYTD(dec.decode(e64.get('data/tweets.js'))).length, 4, 'ZIP64 deflate entry read via extra-field offset');
+eq(parseYTD(dec.decode(e64.get('data/tweets.js'))).length, 4, 'ZIP64 (unc+comp+offset sentinels) deflate entry read');
 eq(parseHandle(dec.decode(e64.get('data/account.js'))), 'pmayrgundter', 'ZIP64 stored entry read');
+
+// Sentinel offset with no resolving extra field -> clean actionable error, not
+// a RangeError('Offset is outside the bounds of the DataView').
+const zBadExtra = makeZip64([{ name: 'data/tweets.js', data: Buffer.from(tweetsJs), deflate: true }], { noExtra: true });
+let te = '';
+try { await readZip(new Blob([zBadExtra]), want); } catch (e) { te = e.message; }
+ok(/tweets\.js/.test(te) && !/DataView/.test(te), 'unresolved ZIP64 sentinel errors cleanly');
 
 // Malformed ZIP64 (sentinels but no locator/record) -> actionable error, not a crash.
 const bad = Buffer.alloc(22);

--- a/net/x/search/lib.test.mjs
+++ b/net/x/search/lib.test.mjs
@@ -139,14 +139,64 @@ ok(!entries.has('data/other.js'), 'zip skipped unwanted');
 eq(parseYTD(dec.decode(entries.get('data/tweets.js'))).length, 4, 'zip deflate roundtrip');
 eq(parseHandle(dec.decode(entries.get('data/account.js'))), 'pmayrgundter', 'zip stored roundtrip');
 
-// ZIP64 (cd offset = 0xffffffff) -> actionable error, not silent empty.
-const z64 = Buffer.alloc(22);
-z64.writeUInt32LE(0x06054b50, 0);
-z64.writeUInt16LE(1, 8); z64.writeUInt16LE(1, 10);
-z64.writeUInt32LE(0xffffffff, 16);
+// --- Real ZIP64 archive (streaming-writer style): per-entry 0xffffffff offset
+// sentinels + ZIP64 extra fields + ZIP64 end-of-directory record/locator.
+// This is the shape X's streamed archives use and what crashed the old reader.
+function makeZip64(entries) {
+  const locals = [], centrals = []; let off = 0;
+  for (const e of entries) {
+    const nb = Buffer.from(e.name), comp = e.deflate ? zlib.deflateRawSync(e.data) : e.data, method = e.deflate ? 8 : 0;
+    const lh = Buffer.alloc(30);
+    lh.writeUInt32LE(0x04034b50, 0); lh.writeUInt16LE(method, 8);
+    lh.writeUInt32LE(comp.length, 18); lh.writeUInt32LE(e.data.length, 22); lh.writeUInt16LE(nb.length, 26);
+    const lr = Buffer.concat([lh, nb, comp]);
+
+    const ch = Buffer.alloc(46);
+    ch.writeUInt32LE(0x02014b50, 0); ch.writeUInt16LE(method, 10);
+    ch.writeUInt32LE(comp.length, 20); ch.writeUInt32LE(e.data.length, 24);
+    ch.writeUInt16LE(nb.length, 28);
+    const extra = Buffer.alloc(12);                 // zip64 extra: real local offset
+    extra.writeUInt16LE(0x0001, 0); extra.writeUInt16LE(8, 2); extra.writeBigUInt64LE(BigInt(off), 4);
+    ch.writeUInt16LE(extra.length, 30);
+    ch.writeUInt32LE(0xffffffff, 42);               // local offset = sentinel
+    centrals.push(Buffer.concat([ch, nb, extra]));
+    locals.push(lr); off += lr.length;
+  }
+  const cdStart = off, cd = Buffer.concat(centrals); off += cd.length;
+
+  const z64 = Buffer.alloc(56);
+  z64.writeUInt32LE(0x06064b50, 0); z64.writeBigUInt64LE(44n, 4);
+  z64.writeUInt16LE(45, 12); z64.writeUInt16LE(45, 14);
+  z64.writeBigUInt64LE(BigInt(entries.length), 24); z64.writeBigUInt64LE(BigInt(entries.length), 32);
+  z64.writeBigUInt64LE(BigInt(cd.length), 40); z64.writeBigUInt64LE(BigInt(cdStart), 48);
+  const z64Off = off;
+
+  const loc = Buffer.alloc(20);
+  loc.writeUInt32LE(0x07064b50, 0); loc.writeBigUInt64LE(BigInt(z64Off), 8); loc.writeUInt32LE(1, 16);
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0xffff, 8); eocd.writeUInt16LE(0xffff, 10);          // sentinel count
+  eocd.writeUInt32LE(0xffffffff, 12); eocd.writeUInt32LE(0xffffffff, 16); // sentinel cd size/offset
+  return Buffer.concat([...locals, cd, z64, loc, eocd]);
+}
+
+const zip64 = makeZip64([
+  { name: 'data/tweets.js', data: Buffer.from(tweetsJs), deflate: true },
+  { name: 'data/account.js', data: Buffer.from(accountJs), deflate: false },
+]);
+const e64 = await readZip(new Blob([zip64]), want);
+eq(parseYTD(dec.decode(e64.get('data/tweets.js'))).length, 4, 'ZIP64 deflate entry read via extra-field offset');
+eq(parseHandle(dec.decode(e64.get('data/account.js'))), 'pmayrgundter', 'ZIP64 stored entry read');
+
+// Malformed ZIP64 (sentinels but no locator/record) -> actionable error, not a crash.
+const bad = Buffer.alloc(22);
+bad.writeUInt32LE(0x06054b50, 0);
+bad.writeUInt16LE(1, 8); bad.writeUInt16LE(1, 10);
+bad.writeUInt32LE(0xffffffff, 16);
 let threw = '';
-try { await readZip(new Blob([z64]), () => true); } catch (e) { threw = e.message; }
-ok(/ZIP64/.test(threw), 'zip64 detected with actionable error');
+try { await readZip(new Blob([bad]), () => true); } catch (e) { threw = e.message; }
+ok(/ZIP64/.test(threw), 'malformed zip64 gives actionable error, no crash');
 
 // Non-zip input -> clear error.
 threw = '';


### PR DESCRIPTION
## Problem

Dropping a real ~1.5 GB X archive `.zip` into Tweet Archive Search crashed with **"Offset is outside the bounds of the DataView"**, even after the earlier slice-based reader fix. Dropping the extracted `data/tweets.js` worked, which localized the bug to the ZIP reader.

## Root cause: ZIP64

X generates archive downloads by **streaming** them, and streaming zip writers force **ZIP64** even for archives under 4 GB. In ZIP64, entry offsets/sizes are stored as `0xFFFFFFFF` sentinels with the true 64-bit values in a per-entry *extra field*, and the central directory is located via a ZIP64 end-of-directory record. The reader took the `0xFFFFFFFF` sentinel literally, sliced ~4 GB past end-of-file, got an empty buffer, and read a `DataView` out of bounds. The earlier synthetic tests were all plain (non-ZIP64) zips, so they never exercised this path.

## Fix

`readZip` now resolves ZIP64 fully:

- follows the ZIP64 end-of-directory **locator → record** for the 64-bit directory count / size / offset;
- parses each entry's ZIP64 **extended-info extra field** (id `0x0001`) for the real compressed size and local-header offset;
- adds defensive offset/bounds checks so anything still unreadable yields a clear "extract data/tweets.js and drop that" message instead of a cryptic `DataView` crash.

Non-ZIP64 archives and the direct `tweets.js` drop are unaffected.

## Testing

- `node net/x/search/lib.test.mjs` → **32 pass**, including a new streaming-style ZIP64 archive (sentinel offsets + extra fields + ZIP64 EOCD/locator) that reproduces the failure and now extracts cleanly, plus a malformed-ZIP64 case that errors gracefully.
- Verified end-to-end in headless Chromium: importing a ZIP64 archive → parse → search → permalink all pass; the pre-fix code throws the exact `DataView` error on the same file.
- Re-ran a 2.2 GB non-ZIP64 archive test — no regression.

## Notes

The previous PR (#12) is merged and closed; this is a fresh change branched from current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2MhXL3RgU862LbZnGcu2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2MhXL3RgU862LbZnGcu2Y)_